### PR TITLE
Fix CSS warnings

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -228,7 +228,7 @@ replyindicator {
 .close-button {
   padding: 3px;
   border-radius: 50%;
-  outline-radius: 50%;
+  -gtk-outline-radius: 50%;
   min-height: 0px;
   min-width: 0px;
   box-shadow: none;

--- a/ui/style.css
+++ b/ui/style.css
@@ -17,7 +17,7 @@
 
 .topbar button image,
 .topbar .button GtkImage {
-  icon-shadow: none;
+  -gtk-icon-shadow: none;
   color: #ddd;
 }
 

--- a/ui/style.css
+++ b/ui/style.css
@@ -234,13 +234,13 @@ replyindicator {
   box-shadow: none;
 }
 
-.avatar:insensitive,
-.inline-media:insensitive {
+.avatar:disabled,
+.inline-media:disabled {
   opacity: 0.4;
 }
 /* Override the earlier rule to read-only
  * inline media are still full-opacity */
-.read-only .inline-media:insensitive {
+.read-only .inline-media:disabled {
   opacity: 1.0;
 }
 


### PR DESCRIPTION
Collectively, these commits get rid of all CSS warnings printed during application startup. See individual commit messages for details.

However, I’m not sure if this is a good idea. The warnings are a bit annoying (especially when they end up polluting the journal, as is the default when launching the app from a GNOME desktop), but on the other hand this will remove compatibility with some older GTK+ releases: specifically, we would now require GTK+ 3.19.6 (just under three years old as of this writing) or newer. Are we likely to have users that need compatibility with older GTK+ versions?